### PR TITLE
Add IOEither methods to README.md

### DIFF
--- a/.changeset/brown-flowers-search.md
+++ b/.changeset/brown-flowers-search.md
@@ -1,0 +1,5 @@
+---
+'jest-fp-ts-matchers': patch
+---
+
+Add IOEither methods to README.md

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install -D jest-fp-ts-matchers
 ```typescript
 import { expectLeftEither } from 'jest-fp-ts-matchers';
 
-test('throws when parsing fails', () => {
+test('returns left Either when parsing fails', () => {
   pipe(
     Parser.parse({ id: '' }),
     expectLeftEither((err) => {
@@ -28,6 +28,8 @@ test('throws when parsing fails', () => {
 
 - `expectLeftEither`
 - `expectRightEither`
+- `expectLeftΙΟEither`
+- `expectRightΙΟEither`
 - `expectLeftTaskEither`
 - `expectRightTaskEither`
 - `expectSomeOption`


### PR DESCRIPTION
Since v.`0.2.0` the library supports the following methods for `IOEither` structures:

- `expectLeftΙΟEither`
- `expectRightΙΟEither`

However, the README was not updated to reflect the latest changes. This PR addresses the issue.