### PR TITLE
chore: move `@swc/helpers` to devDependencies

### DIFF
--- a/.changeset/quiet-penguins-argue.md
+++ b/.changeset/quiet-penguins-argue.md
@@ -1,0 +1,5 @@
+---
+'jest-fp-ts-matchers': patch
+---
+
+move @swc/helpers to devDependencies

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@commitlint/config-conventional": "^15.0.0",
     "@swc/cli": "^0.1.55",
     "@swc/core": "^1.2.121",
+    "@swc/helpers": "^0.5.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
@@ -82,9 +83,6 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^27.0.5",
     "typescript": "^4.2.3"
-  },
-  "peerDependencies": {
-    "@swc/helpers": "^0.3.2"
   },
   "dependencies": {
     "fp-ts": "^2.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,6 +1040,13 @@
     "@swc/core-win32-ia32-msvc" "1.2.172"
     "@swc/core-win32-x64-msvc" "1.2.172"
 
+"@swc/helpers@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.0.tgz#bf1d807b60f7290d0ec763feea7ccdeda06e85f1"
+  integrity sha512-SjY/p4MmECVVEWspzSRpQEM3sjR17sP8PbGxELWrT+YZMBfiUyt1MRUNjMV23zohwlG2HYtCQOsCwsTHguXkyg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -4587,6 +4594,11 @@ tslib@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
This PR moves the `@swc/helpers` package inside `devDependencies` instead of `peerDependencies`