### PR TITLE
chore: move @swc/helpers to dependencies

### DIFF
--- a/.changeset/twelve-spies-shout.md
+++ b/.changeset/twelve-spies-shout.md
@@ -1,0 +1,5 @@
+---
+'jest-fp-ts-matchers': patch
+---
+
+move @swc/helpers inside npm dependencies

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@commitlint/config-conventional": "^15.0.0",
     "@swc/cli": "^0.1.55",
     "@swc/core": "^1.2.121",
-    "@swc/helpers": "^0.5.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
@@ -85,6 +84,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@swc/helpers": "^0.5.0",
     "fp-ts": "^2.12.1"
   }
 }


### PR DESCRIPTION
This PR moves the `@swc/helpers` package inside the npm dependencies