### PR TITLE
Add matchers for ReaderTaskEither

### DIFF
--- a/.changeset/thirty-badgers-relax.md
+++ b/.changeset/thirty-badgers-relax.md
@@ -1,0 +1,5 @@
+---
+'jest-fp-ts-matchers': minor
+---
+
+Add matchers for ReaderTaskEither

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ test('returns left Either when parsing fails', () => {
 - `expectRightΙΟEither`
 - `expectLeftTaskEither`
 - `expectRightTaskEither`
+- `expectLeftReaderTaskEither`
+- `expectRightReaderTaskEither`
 - `expectSomeOption`
 - `expectNoneOption`
 

--- a/lib/expectLeftReaderTaskEither.test.ts
+++ b/lib/expectLeftReaderTaskEither.test.ts
@@ -1,0 +1,26 @@
+import * as ReaderTaskEither from 'fp-ts/ReaderTaskEither';
+
+import { expectLeftReaderTaskEither } from './expectLeftReaderTaskEither';
+
+describe('expectLeftReaderTaskEither', () => {
+  test('should call the handler if `ReaderTaskEither.left`', async () => {
+    const handler = jest.fn();
+    const monad = ReaderTaskEither.left(new Error('error'));
+
+    await expectLeftReaderTaskEither(handler)(monad)(null)();
+
+    expect(handler).toHaveBeenCalledWith(new Error('error'));
+  });
+
+  test('should throw if `ReaderTaskEither.right`', async () => {
+    const handler = jest.fn();
+    const monad = ReaderTaskEither.right(1);
+
+    try {
+      await expectLeftReaderTaskEither(handler)(monad)(null)();
+    } catch (error) {
+      expect(error).toEqual(new Error('It should not succeed'));
+      expect(handler).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/lib/expectLeftReaderTaskEither.ts
+++ b/lib/expectLeftReaderTaskEither.ts
@@ -1,0 +1,9 @@
+import type { ReaderTask } from 'fp-ts/ReaderTask';
+import * as ReaderTaskEither from 'fp-ts/ReaderTaskEither';
+
+export const expectLeftReaderTaskEither =
+  <R, E, A>(leftHandler: (error: E) => void) =>
+  (ma: ReaderTaskEither.ReaderTaskEither<R, E, A>): ReaderTask<R, void> =>
+    ReaderTaskEither.match(leftHandler, () => {
+      throw new Error('It should not succeed');
+    })(ma);

--- a/lib/expectRightReaderTaskEither.test.ts
+++ b/lib/expectRightReaderTaskEither.test.ts
@@ -1,0 +1,25 @@
+import * as ReaderTaskEither from 'fp-ts/ReaderTaskEither';
+
+import { expectRightReaderTaskEither } from './expectRightReaderTaskEither';
+
+describe('expectRightReaderTaskEither', () => {
+  test('should call right handler if `ReaderTaskEither.right`', async () => {
+    const handler = jest.fn();
+    const monad = ReaderTaskEither.right(1);
+
+    await expectRightReaderTaskEither(handler)(monad)(null)();
+    expect(handler).toHaveBeenCalledWith(1);
+  });
+
+  test('should throw if `ReaderTaskEither.left`', async () => {
+    const handler = jest.fn();
+    const monad = ReaderTaskEither.left(new Error('error'));
+
+    try {
+      await expectRightReaderTaskEither(handler)(monad)(null)();
+    } catch (error) {
+      expect(error).toEqual(new Error('error'));
+      expect(handler).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/lib/expectRightReaderTaskEither.ts
+++ b/lib/expectRightReaderTaskEither.ts
@@ -1,0 +1,9 @@
+import type { ReaderTask } from 'fp-ts/ReaderTask';
+import * as ReaderTaskEither from 'fp-ts/ReaderTaskEither';
+
+export const expectRightReaderTaskEither =
+  <R, E, A>(rightHandler: (value: A) => void) =>
+  (ma: ReaderTaskEither.ReaderTaskEither<R, E, A>): ReaderTask<R, void> =>
+    ReaderTaskEither.match((error) => {
+      throw error;
+    }, rightHandler)(ma);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,9 @@ export { expectRightEither } from './expectRightEither';
 export { expectLeftTaskEither } from './expectLeftTaskEither';
 export { expectRightTaskEither } from './expectRightTaskEither';
 
+export { expectLeftReaderTaskEither } from './expectLeftReaderTaskEither';
+export { expectRightReaderTaskEither } from './expectRightReaderTaskEither';
+
 export { expectNoneOption } from './expectNoneOption';
 export { expectSomeOption } from './expectSomeOption';
 


### PR DESCRIPTION
Add matchers and relevant tests for `ReaderTaskEither`.