### PR TITLE
feat: introduce jest matchers for ReaderEither monad

### DIFF
--- a/lib/expectLeftReaderEither.test.ts
+++ b/lib/expectLeftReaderEither.test.ts
@@ -1,0 +1,26 @@
+import * as ReaderEither from 'fp-ts/ReaderEither';
+
+import { expectLeftReaderEither } from './expectLeftReaderEither';
+
+describe('expectLeftReaderEither', () => {
+  test('should call the handler if `ReaderEither.left`', () => {
+    const handler = jest.fn();
+    const monad = ReaderEither.left(new Error('error'));
+
+    expectLeftReaderEither(handler)(monad)(null);
+
+    expect(handler).toHaveBeenCalledWith(new Error('error'));
+  });
+
+  test('should throw if `ReaderEither.right`', () => {
+    const handler = jest.fn();
+    const monad = ReaderEither.right(1);
+
+    try {
+      expectLeftReaderEither(handler)(monad)(null);
+    } catch (error) {
+      expect(error).toEqual(new Error('It should not succeed'));
+      expect(handler).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/lib/expectLeftReaderEither.ts
+++ b/lib/expectLeftReaderEither.ts
@@ -1,0 +1,9 @@
+import type { Reader } from 'fp-ts/Reader';
+import * as ReaderEither from 'fp-ts/ReaderEither';
+
+export const expectLeftReaderEither =
+  <R, E, A>(leftHandler: (error: E) => void) =>
+  (ma: ReaderEither.ReaderEither<R, E, A>): Reader<R, void> =>
+    ReaderEither.match(leftHandler, () => {
+      throw new Error('It should not succeed');
+    })(ma);

--- a/lib/expectRightReaderEither.test.ts
+++ b/lib/expectRightReaderEither.test.ts
@@ -1,0 +1,25 @@
+import * as ReaderEither from 'fp-ts/ReaderEither';
+
+import { expectRightReaderEither } from './expectRightReaderEither';
+
+describe('expectRightReaderEither', () => {
+  test('should call right handler if `ReaderEither.right`', async () => {
+    const handler = jest.fn();
+    const monad = ReaderEither.right(1);
+
+    expectRightReaderEither(handler)(monad)(null);
+    expect(handler).toHaveBeenCalledWith(1);
+  });
+
+  test('should throw if `ReaderEither.left`', async () => {
+    const handler = jest.fn();
+    const monad = ReaderEither.left(new Error('error'));
+
+    try {
+      expectRightReaderEither(handler)(monad)(null);
+    } catch (error) {
+      expect(error).toEqual(new Error('error'));
+      expect(handler).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/lib/expectRightReaderEither.ts
+++ b/lib/expectRightReaderEither.ts
@@ -1,0 +1,9 @@
+import type { Reader } from 'fp-ts/Reader';
+import * as ReaderEither from 'fp-ts/ReaderEither';
+
+export const expectRightReaderEither =
+  <R, E, A>(rightHandler: (value: A) => void) =>
+  (ma: ReaderEither.ReaderEither<R, E, A>): Reader<R, void> =>
+    ReaderEither.match((error) => {
+      throw error;
+    }, rightHandler)(ma);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,9 @@
 export { expectLeftEither } from './expectLeftEither';
 export { expectRightEither } from './expectRightEither';
 
+export { expectLeftReaderEither } from './expectLeftReaderEither';
+export { expectRightReaderEither } from './expectRightReaderEither';
+
 export { expectLeftTaskEither } from './expectLeftTaskEither';
 export { expectRightTaskEither } from './expectRightTaskEither';
 


### PR DESCRIPTION
This PR introduces jest matchers for the `ReaderEither` monad.